### PR TITLE
Update index.genotype.R

### DIFF
--- a/R/index.genotype.R
+++ b/R/index.genotype.R
@@ -14,7 +14,7 @@ index.genotype <- function(file){
   }
 
   ## Check column names and order
-  snp50 = utils::read.table(file, sep="\t", header=TRUE, quote="", comment.char = "#", as.is=TRUE, nrows=50)
+  snp50 = utils::read.table(file, sep="\t", header=TRUE, quote="", comment.char = "", as.is=TRUE, nrows=50)
   if(!all(colnames(snp50)[1:4] == c("chr","start","end","snpId"))){
     stop("Missing column or in incorrect order. The first 4 columns must be 'chr', 'start', 'end' and 'snpId'.")
   }
@@ -24,6 +24,6 @@ index.genotype <- function(file){
   }
   
   file.final = Rsamtools::bgzip(file, dest=paste0(sub(".gz","",file),".bgz"),overwrite=TRUE)
-  Rsamtools::indexTabix(file.final, format="bed",comment="#")
+  Rsamtools::indexTabix(file.final, format="bed",skip=1L)
   return(file.final)
 }

--- a/R/index.genotype.R
+++ b/R/index.genotype.R
@@ -14,7 +14,7 @@ index.genotype <- function(file){
   }
 
   ## Check column names and order
-  snp50 = utils::read.table(file, sep="\t", header=TRUE, quote="", comment.char = "", as.is=TRUE, nrows=50)
+  snp50 = utils::read.table(file, sep="\t", header=TRUE, quote="", comment.char = "#", as.is=TRUE, nrows=50)
   if(!all(colnames(snp50)[1:4] == c("chr","start","end","snpId"))){
     stop("Missing column or in incorrect order. The first 4 columns must be 'chr', 'start', 'end' and 'snpId'.")
   }
@@ -24,6 +24,6 @@ index.genotype <- function(file){
   }
   
   file.final = Rsamtools::bgzip(file, dest=paste0(sub(".gz","",file),".bgz"),overwrite=TRUE)
-  Rsamtools::indexTabix(file.final, format="bed")
+  Rsamtools::indexTabix(file.final, format="bed",comment="#")
   return(file.final)
 }


### PR DESCRIPTION
Reformat genotype file header with a leading "#" to omit the first line when index:
#chr start end snpId
Rsamtools::indexTabix goes wrong to:
[E::get_intv] failed to parse TBX_GENERIC, was wrong -p [type] used?